### PR TITLE
modify DetectorUtil to handle the failing tests in original order

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
@@ -23,8 +23,29 @@ import java.util.stream.Stream;
 public class DetectorUtil {
 
     //
+    private static boolean analyzed = false;
+    private static List<String> passOriginalOrder = new ArrayList();
     private static List<String> NODs = new ArrayList();
     private static List<String> consistentlyFail = new ArrayList();
+
+    public static List<String> getPassOriginalOrder(){
+        if(analyzed){
+            throw new NoPassingOrderException("PassOriginalOrder haven't be created");
+        }
+        return passOriginalOrder;
+    }
+    public static List<String> getNODs(){
+        if(analyzed){
+            throw new NoPassingOrderException("NODs haven't be created");
+        }
+        return NODs;
+    }
+    public static List<String> consistentlyFail(){
+        if(analyzed){
+            throw new NoPassingOrderException("consistentlyFail haven't be created");
+        }
+        return consistentlyFail;
+    }
     //
 
     public static TestRunResult originalResults(final List<String> originalOrder, final Runner runner) {
@@ -65,7 +86,7 @@ public class DetectorUtil {
                     System.out.println(str);
                     TestResult temp = origResult.results().get(str); //get the test result for specific string from map
                     if(!(temp.result().equals(Result.PASS) || temp.result().equals(Result.SKIPPED))) {
-                        int timesOfFAIL = 1; // need to be modified
+                        int timesOfFAIL = 1;
                         if(record.containsKey(str)) {
                             timesOfFAIL += record.get(str);
                         }
@@ -96,20 +117,25 @@ public class DetectorUtil {
                 Integer value = record.get(str);
                 if(value >= tolerance) {
                     newOrder.remove(str);
+                    String typeOfRemovedTest;
                     if(value == originalOrderTries){
                         consistentlyFail.add(str);
+                        typeOfRemovedTest = "consistentlyFail";
                     } else {
                         NODs.add(str);
+                        typeOfRemovedTest = "NOD";
                     }
+                    System.out.println(str + " removed (" + typeOfRemovedTest + ")");
                     break; //depend on our configuration - delete xxx tests all together or one by one
                 }
             }
             //with newOrder, rerun the function
-            origResult = originalResults(newOrder, runner);
+            origResult = DetectorUtil.originalResults(newOrder, runner); //added "DetectorUtil." before originalResults
+            passOriginalOrder = newOrder;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             //}
         } else {
-            System.out.println("-------------------------------[TEST RESULT]-------------------------------");
+            System.out.println("-------------------------------<TEST RESULT>-------------------------------");
             System.out.println("Passing Order");
             for (Iterator iter = newOrder.iterator(); iter.hasNext();) {
                 String str = (String) iter.next();
@@ -125,9 +151,8 @@ public class DetectorUtil {
                 String str = (String) iter.next();
                 System.out.println(str);
             }
-            System.out.println("-------------------------------[TEST RESULT]-------------------------------\"");
+            System.out.println("-------------------------------<TEST RESULT>-------------------------------\"");
         }
-
         return origResult;
     }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
@@ -8,25 +8,40 @@ import com.reedoei.testrunner.mavenplugin.TestPluginPlugin;
 import com.reedoei.testrunner.runner.Runner;
 import edu.illinois.cs.dt.tools.runner.data.DependentTest;
 import edu.illinois.cs.dt.tools.runner.data.TestRun;
+import scala.collection.Set;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 public class DetectorUtil {
+
+    //
+    private static List<String> NODs = new ArrayList();
+    private static List<String> consistentlyFail = new ArrayList();
+    //
+
     public static TestRunResult originalResults(final List<String> originalOrder, final Runner runner) {
         final int originalOrderTries = Configuration.config().getProperty("dt.detector.original_order.retry_count", 3);
         final boolean allMustPass = Configuration.config().getProperty("dt.detector.original_order.all_must_pass", true);
 
         System.out.println("[INFO] Getting original results (" + originalOrder.size() + " tests).");
 
-        TestRunResult origResult = null;
+//////
+        int maxFailTimes = 0;
+        int passrounds = 0;
+//////
 
-        boolean allPassing = false;
+        TestRunResult origResult = null;
+        Map<String, Integer> record = new HashMap<String, Integer>(); //build a map link the string and number of times it fails
+
+        //boolean allPassing = false;
         // Try to run it three times, to see if we can get everything to pass (except for ignored tests)
         for (int i = 0; i < originalOrderTries; i++) {
             origResult = runner.runList(originalOrder).get();
@@ -37,17 +52,80 @@ public class DetectorUtil {
             } catch (IOException ignored) {}
 
             if (allPass(origResult)) {
-                allPassing = true;
-                break;
-            }
-        }
+                //allPassing = true;
+                passrounds += 1;
+                //break;
+                //rather than break immediately when there is a passing round, I would like to run all rounds for checking NOD tests
 
-        if (!allPassing) {
-            if (allMustPass) {
-                throw new NoPassingOrderException("No passing order for tests (" + originalOrderTries + " runs)");
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             } else {
-                TestPluginPlugin.info("No passing order for tests (" + originalOrderTries + " runs). Continuing anyway with last run.");
+                System.out.println("Analyzing...");
+                for (Iterator iter = originalOrder.iterator(); iter.hasNext();) { //a iter to go through every string
+                    String str = (String)iter.next();
+                    System.out.println(str);
+                    TestResult temp = origResult.results().get(str); //get the test result for specific string from map
+                    if(!(temp.result().equals(Result.PASS) || temp.result().equals(Result.SKIPPED))) {
+                        int timesOfFAIL = 1; // need to be modified
+                        if(record.containsKey(str)) {
+                            timesOfFAIL += record.get(str);
+                        }
+                        record.put(str, timesOfFAIL);
+                        if(timesOfFAIL > maxFailTimes){
+                            maxFailTimes = timesOfFAIL; //record the maxFailTime after xxx tests do not exist
+                        }
+                    }
+                }
             }
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        }
+        List<String> newOrder = originalOrder;
+
+        if (passrounds != originalOrderTries) {
+            //if (allMustPass) {
+            //    throw new NoPassingOrderException("No passing order for tests (" + originalOrderTries + " runs)");
+            //} else {
+            //TestPluginPlugin.info("No passing order for tests (" + originalOrderTries + " runs). Continuing anyway with last run.");
+            TestPluginPlugin.info("Consistently fail tests or NOD tests exist (" + originalOrderTries + " runs). Removing fail tests");
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            Iterator<String> iter = record.keySet().iterator();
+            //Integer tolerance = originalOrderTries;
+            Integer tolerance = maxFailTimes;
+            while(iter.hasNext()){
+                String str=iter.next();
+                Integer value = record.get(str);
+                if(value >= tolerance) {
+                    newOrder.remove(str);
+                    if(value == originalOrderTries){
+                        consistentlyFail.add(str);
+                    } else {
+                        NODs.add(str);
+                    }
+                    break; //depend on our configuration - delete xxx tests all together or one by one
+                }
+            }
+            //with newOrder, rerun the function
+            origResult = originalResults(newOrder, runner);
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            //}
+        } else {
+            System.out.println("-------------------------------[TEST RESULT]-------------------------------");
+            System.out.println("Passing Order");
+            for (Iterator iter = newOrder.iterator(); iter.hasNext();) {
+                String str = (String) iter.next();
+                System.out.println(str);
+            }
+            System.out.println("Consistently Fails");
+            for (Iterator iter = consistentlyFail.iterator(); iter.hasNext();) {
+                String str = (String) iter.next();
+                System.out.println(str);
+            }
+            System.out.println("NODs");
+            for (Iterator iter = NODs.iterator(); iter.hasNext();) {
+                String str = (String) iter.next();
+                System.out.println(str);
+            }
+            System.out.println("-------------------------------[TEST RESULT]-------------------------------\"");
         }
 
         return origResult;


### PR DESCRIPTION
DetectorUtil.java inside /src/main/java/edu/illinois/cs/dt/tools/detection/ is modified. 
It creates a hashmap to store the times of failing for each test in the original order. The tests that consistently fail will be recorded in an ArrayList and removed one by one or all together based on configuration. The NOD tests found during running will also be recorded in a separate ArrayList.
There is a [demo project](https://github.com/frankyhao/mavendemoproject) that contains a consistently pass test, a consistently fail test and a NOD test that fails 1/3 times. Detailed instruction is provided inside its repository.