### PR TITLE
Minor script fixes

### DIFF
--- a/scripts/docker/baseDockerfile
+++ b/scripts/docker/baseDockerfile
@@ -40,7 +40,7 @@ WORKDIR /home/idflakies/
 RUN \
   wget http://mirrors.ibiblio.org/apache/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz && \
   tar -xzf apache-maven-3.5.4-bin.tar.gz && mv apache-maven-3.5.4/ apache-maven/ && \
-  echo 'export JAVA_HOME=/usr/lib/jvm/java-8-oracle' >> ~/.bashrc && \
+  echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/' >> ~/.bashrc && \
   echo 'export M2_HOME=${HOME}/apache-maven' >> ~/.bashrc && \
   echo 'export MAVEN_HOME=${HOME}/apache-maven' >> ~/.bashrc && \
   echo 'export PATH=${M2_HOME}/bin:${PATH}' >> ~/.bashrc

--- a/scripts/docker/run_project.sh
+++ b/scripts/docker/run_project.sh
@@ -25,9 +25,6 @@ timeout=$3
 cd "/home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/"
 ./setup
 
-# Set environment up, just in case
-source ~/.bashrc
-
 # Incorporate tooling into the project, using Java XML parsing
 cd "/home/$SCRIPT_USERNAME/${slug}"
 /home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/docker/pom-modify/modify-project.sh .

--- a/scripts/docker/run_project.sh
+++ b/scripts/docker/run_project.sh
@@ -87,20 +87,11 @@ date
 
 timeout ${timeout}s /home/$SCRIPT_USERNAME/apache-maven/bin/mvn testrunner:testplugin ${MVNOPTIONS} -Ddetector.timeout=${timeout} -Ddt.randomize.rounds=${rounds} -Ddetector.detector_type=smart-shuffle -fn -B -e |& tee smart_shuffle.log
 
-
 # Gather the results, put them up top
 RESULTSDIR=/home/$SCRIPT_USERNAME/output/
 mkdir -p ${RESULTSDIR}
 /home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/gather-results $(pwd) ${RESULTSDIR}
-mv module_test_time.log ${RESULTSDIR}
-mv original.log ${RESULTSDIR}
-mv random_class_method.log ${RESULTSDIR}
-mv random_class.log ${RESULTSDIR}
-mv reverse_original.log ${RESULTSDIR}
-mv reverse_class.log ${RESULTSDIR}
-mv mvn-test.log ${RESULTSDIR}
-mv mvn-test-time.log ${RESULTSDIR}
-
+mv *.log ${RESULTSDIR}/
 
 echo "*******************REED************************"
 echo "Finished run_project.sh"


### PR DESCRIPTION
When running an interactive shell for the idflakies user in a docker container created with iDFlakies, JAVA_HOME points to an invalid path in the container. The reason this did not affect the automated execution is that the environment is inherited from the root user when running scripts via "su - idflakies -c" and that .bashrc is not loaded for non-interactive shells (see first guard in .bashrc). To observe the issue, start an interactive shell for the idflakies user in any docker container created by the scripts and try to run maven.

- The pull request sets JAVA_HOME to the same value as for the root user's environment in order to make it work for interactive sessions (e.g., for debugging).
- As I consider it unlikely that the 'non-interactive guard' will ever be dropped from .bashrc, the pull request also removes the ineffective source instruction from run_project.sh.