### PR TITLE
Feature: make idflakies version configurable

### DIFF
--- a/scripts/docker/pom-modify/modify-project.sh
+++ b/scripts/docker/pom-modify/modify-project.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-if [ "$1" == "" ]; then
+if [ "$1" == "" -o "$2" == "" ]; then
     echo "arg1 - the path to the project, where high-level pom.xml is"
+    echo "arg2 - the version number of iDFlakies to use"
     exit
 fi
 
 crnt=`pwd`
 working_dir=`dirname $0`
 project_path=$1
+version=$2
 
 cd ${project_path}
 project_path=`pwd`
@@ -24,7 +26,7 @@ function process_poms
 
 #find ${project_path} -name pom.xml | process_poms
 javac PomFile.java
-find ${project_path} -name pom.xml | grep -v "src/" | java PomFile
-rm -f PomFile.class
+find ${project_path} -name pom.xml | grep -v "src/" | java PomFile $version
+rm -f PomFile*.class
 
 cd ${crnt}

--- a/scripts/docker/run_project.sh
+++ b/scripts/docker/run_project.sh
@@ -21,6 +21,8 @@ slug=$1
 rounds=$2
 timeout=$3
 
+iDFlakiesVersion=1.0.0
+
 # Setup prolog stuff
 cd "/home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/"
 ./setup
@@ -30,7 +32,7 @@ source ~/.bashrc
 
 # Incorporate tooling into the project, using Java XML parsing
 cd "/home/$SCRIPT_USERNAME/${slug}"
-/home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/docker/pom-modify/modify-project.sh .
+/home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/docker/pom-modify/modify-project.sh . $iDFlakiesVersion
 
 # Run the plugin, get module test times
 echo "*******************REED************************"
@@ -90,20 +92,11 @@ date
 
 timeout ${timeout}s /home/$SCRIPT_USERNAME/apache-maven/bin/mvn testrunner:testplugin ${MVNOPTIONS} -Ddetector.timeout=${timeout} -Ddt.randomize.rounds=${rounds} -Ddetector.detector_type=smart-shuffle -fn -B -e |& tee smart_shuffle.log
 
-
 # Gather the results, put them up top
 RESULTSDIR=/home/$SCRIPT_USERNAME/output/
 mkdir -p ${RESULTSDIR}
 /home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/gather-results $(pwd) ${RESULTSDIR}
-mv module_test_time.log ${RESULTSDIR}
-mv original.log ${RESULTSDIR}
-mv random_class_method.log ${RESULTSDIR}
-mv random_class.log ${RESULTSDIR}
-mv reverse_original.log ${RESULTSDIR}
-mv reverse_class.log ${RESULTSDIR}
-mv mvn-test.log ${RESULTSDIR}
-mv mvn-test-time.log ${RESULTSDIR}
-
+mv *.log ${RESULTSDIR}/
 
 echo "*******************REED************************"
 echo "Finished run_project.sh"


### PR DESCRIPTION
The pom file patching tool of iDFlakies adds a fixed version number, which matches the version currently on Maven Central. As a consequence, the existing script infrastructure for execution automation cannot be used out of the box with development versions of iDFlakies. This feature makes the version adjustable and sets the default so that there is no difference in the standard behavior. The version is currently defined as a variable in the run_project.sh script. In order to facilitate development and debugging, the feature also modifies the pom patching tool to first check if a pom file has already been patched before proceeding with pom file analysis and rewriting and, if so, skips further patching.