### PR TITLE
More generic operation to store back result logs

### DIFF
--- a/scripts/docker/run_project.sh
+++ b/scripts/docker/run_project.sh
@@ -90,20 +90,11 @@ date
 
 timeout ${timeout}s /home/$SCRIPT_USERNAME/apache-maven/bin/mvn testrunner:testplugin ${MVNOPTIONS} -Ddetector.timeout=${timeout} -Ddt.randomize.rounds=${rounds} -Ddetector.detector_type=smart-shuffle -fn -B -e |& tee smart_shuffle.log
 
-
 # Gather the results, put them up top
 RESULTSDIR=/home/$SCRIPT_USERNAME/output/
 mkdir -p ${RESULTSDIR}
 /home/$SCRIPT_USERNAME/$TOOL_REPO/scripts/gather-results $(pwd) ${RESULTSDIR}
-mv module_test_time.log ${RESULTSDIR}
-mv original.log ${RESULTSDIR}
-mv random_class_method.log ${RESULTSDIR}
-mv random_class.log ${RESULTSDIR}
-mv reverse_original.log ${RESULTSDIR}
-mv reverse_class.log ${RESULTSDIR}
-mv mvn-test.log ${RESULTSDIR}
-mv mvn-test-time.log ${RESULTSDIR}
-
+mv *.log ${RESULTSDIR}/
 
 echo "*******************REED************************"
 echo "Finished run_project.sh"


### PR DESCRIPTION
replaced mv ops on explicit set of log files with wildcard to mute errors if only a subset is created and also support supersets in case of future extensions