### PR TITLE
Added configurability of iDFlakies' behavior when the initial run of …

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/utility/GetMavenTestOrder.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/GetMavenTestOrder.java
@@ -21,8 +21,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import edu.illinois.cs.testrunner.configuration.Configuration;
 
 public class GetMavenTestOrder extends StandardMain {
+
+    private boolean mvnTestMustPass = Boolean.parseBoolean(Configuration.config().getProperty("dt.mvn_test.must_pass","true"));
+    
     @Override
     protected void run() throws Exception {
         final List<String> classOrder = getClassOrder(mvnTestLog.toFile());
@@ -170,11 +174,13 @@ public class GetMavenTestOrder extends StandardMain {
         int errors = Integer.parseInt(rootElement.getAttribute("errors"));
         int failures = Integer.parseInt(rootElement.getAttribute("failures"));
 
-        if (errors != 0 || failures != 0) {
-            // errors/failures found in the test suite from running mvn test.
-            // this test suite should not proceed to use detectors
-            throw new RuntimeException("Failures or errors occurred in mvn test");
-        }
+	if (mvnTestMustPass){
+	    if (errors != 0 || failures != 0) {
+		// errors/failures found in the test suite from running mvn test.
+		// this test suite should not proceed to use detectors
+		throw new RuntimeException("Failures or errors occurred in mvn test");
+	    }
+	}
 
         className = rootElement.getAttribute("name");
         testTime = Double.parseDouble(rootElement.getAttribute("time"));


### PR DESCRIPTION
…'mvn test' (e.g., during container creation) has errors or failures. The standard behavior of iDFlakies is to throw an exception in this case. For NOD flaky tests, this implied requirement of a passing mvn test run is overly restrictive, as NOD flaky tests can fail even during the initial run. To accommodate for this possibility, a property 'dt.mvn_test.must_pass' is introduced, which is set to true by default. This resembles iDFlakies' original behavior. If set to false, the check for mvn test errors or failures is simply skipped and no exception is thrown.