### PR TITLE
Property naming inconsistency

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/detection/detectors/ExecutingDetector.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/detectors/ExecutingDetector.java
@@ -99,7 +99,7 @@ public abstract class ExecutingDetector implements Detector, VerbosePrinter {
         private final long origStartTimeMs = System.currentTimeMillis();
         private long startTimeMs = System.currentTimeMillis();
         private long previousStopTimeMs = System.currentTimeMillis();
-	private boolean roundsAreTotal = Boolean.parseBoolean(Configuration.config().getProperty("detector.roundsemantics.total", "false"));
+	private boolean roundsAreTotal = Boolean.parseBoolean(Configuration.config().getProperty("dt.detector.roundsemantics.total", "false"));
 
         private int i = 0;
 


### PR DESCRIPTION
Fixed an inconsistency between the property name for configuring round count semantics used in the implementation vs. the naming in the PR text. Now it's a combination of both that's closer to the naming of other properties for configuring iDFlakies.