### PR TITLE
Fix write originalResultsLog bugs

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
@@ -33,7 +33,7 @@ public class DetectorUtil {
 
             try {
                 Files.write(DetectorPathManager.originalResultsLog(), (origResult.id() + "\n").getBytes(),
-                        Files.exists(DetectorPathManager.originalOrderPath()) ? StandardOpenOption.APPEND : StandardOpenOption.CREATE);
+                        Files.exists(DetectorPathManager.originalResultsLog()) ? StandardOpenOption.APPEND : StandardOpenOption.CREATE);
             } catch (IOException ignored) {}
 
             if (allPass(origResult)) {


### PR DESCRIPTION
Hi,

I find that there is a bug in DetectorUtil.java when we want to write a log to _originalResultsLog_, it will check the existence of _originalOrderPath_ instead of _originalResultsLog_ itself, and based on this existence, it will choose _APPEND_ or _CREATE_ operations.