### PR TITLE
Extend testrunner to be gradle compatible

### DIFF
--- a/pom-modify/PomFile.java
+++ b/pom-modify/PomFile.java
@@ -205,7 +205,7 @@ public class PomFile {
             }
             {
                 Node version = doc.createElement("version");
-                version.setTextContent("1.1");
+                version.setTextContent("1.2");
                 plugin.appendChild(version);
             }
             {

--- a/pom-modify/modify-project.sh
+++ b/pom-modify/modify-project.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ARTIFACT_ID="idflakies"
-ARTIFACT_VERSION="1.1.0"
+ARTIFACT_VERSION="1.2.0"
 CONFIGURATION_CLASS="edu.illinois.cs.dt.tools.detection.DetectorPlugin"
 
 if [[ $1 == "" ]]; then

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-invoker</artifactId>
-            <version>3.0.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>4.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.illinois.cs</groupId>
     <artifactId>idflakies</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <name>iDFlakies</name>
     <description>A tool for detecting flaky tests</description>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>edu.illinois.cs</groupId>
             <artifactId>testrunner-core-plugin</artifactId>
-            <version>1.1</version>
+            <version>1.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependencies>
         <dependency>
             <groupId>edu.illinois.cs</groupId>
-            <artifactId>testrunner-maven-plugin</artifactId>
+            <artifactId>testrunner-core-plugin</artifactId>
             <version>1.1</version>
         </dependency>
 

--- a/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorPlugin.java
@@ -11,8 +11,8 @@ import edu.illinois.cs.dt.tools.utility.GetMavenTestOrder;
 import edu.illinois.cs.dt.tools.utility.TestClassData;
 import edu.illinois.cs.testrunner.configuration.Configuration;
 import edu.illinois.cs.testrunner.data.framework.TestFramework;
-import edu.illinois.cs.testrunner.mavenplugin.TestPlugin;
-import edu.illinois.cs.testrunner.mavenplugin.TestPluginPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 import edu.illinois.cs.testrunner.runner.Runner;
 import edu.illinois.cs.testrunner.runner.RunnerFactory;
 import edu.illinois.cs.testrunner.testobjects.TestLocator;
@@ -126,7 +126,7 @@ public class DetectorPlugin extends TestPlugin {
             }
         }
 
-        TestPluginPlugin.mojo().getLog().info("TIMEOUT_CALCULATED: Giving " + coordinates + " " + timeout + " seconds to run for " +
+        TestPluginUtil.info("TIMEOUT_CALCULATED: Giving " + coordinates + " " + timeout + " seconds to run for " +
             DetectorFactory.detectorType());
 
         return (long) timeout; // Allocate time proportionally
@@ -158,25 +158,25 @@ public class DetectorPlugin extends TestPlugin {
                 final double totalTime = readRealTime(timeCsv);
                 final double mainTimeout = Configuration.config().getProperty("detector.timeout", 6 * 3600.0); // 6 hours
                 if (mainTimeout != 0) {
-                    TestPluginPlugin.mojo().getLog().info("TIMEOUT_VALUE: Using a timeout of "
+                    TestPluginUtil.info("TIMEOUT_VALUE: Using a timeout of "
                                                           + mainTimeout + ", and that the total mvn test time is: " + totalTime);
 
                     timeoutRounds = (int) (mainTimeout / totalTime);
                 } else {
                     timeoutRounds = roundNum;
-                    TestPluginPlugin.mojo().getLog().info("TIMEOUT_VALUE specified as 0. " +
+                    TestPluginUtil.info("TIMEOUT_VALUE specified as 0. " +
                                                           "Ignoring timeout and using number of rounds.");
                 }
             } else {
                 // Depending on the order in which the developers tell Maven to build modules, some projects like http-request
                 // may not be able to parse the mvn-test-time.log at the base module if other submodules are built first
                 timeoutRounds = roundNum;
-                TestPluginPlugin.mojo().getLog().info("TIMEOUT_VALUE specified but cannot " +
+                TestPluginUtil.info("TIMEOUT_VALUE specified but cannot " +
                                                       "read mvn-test-time.log at: " + timeCsv.toString());
-                TestPluginPlugin.mojo().getLog().info("Ignoring timeout and using number of rounds.");
+                TestPluginUtil.info("Ignoring timeout and using number of rounds.");
             }
         } else {
-            TestPluginPlugin.mojo().getLog().info("No timeout specified. Using randomize.rounds: " + roundNum);
+            TestPluginUtil.info("No timeout specified. Using randomize.rounds: " + roundNum);
             timeoutRounds = roundNum;
         }
 
@@ -187,7 +187,7 @@ public class DetectorPlugin extends TestPlugin {
             rounds = Math.min(timeoutRounds, roundNum);
         }
 
-        TestPluginPlugin.mojo().getLog().info("ROUNDS_CALCULATED: Giving " + coordinates + " "
+        TestPluginUtil.info("ROUNDS_CALCULATED: Giving " + coordinates + " "
                 + rounds + " rounds to run for " + DetectorFactory.detectorType());
 
         return rounds;
@@ -224,7 +224,7 @@ public class DetectorPlugin extends TestPlugin {
                     "This project contains both JUnit 4 and JUnit 5 tests, which currently"
                     + " is not supported by iDFlakies";
             }
-            TestPluginPlugin.info(errorMsg);
+            TestPluginUtil.info(errorMsg);
             logger.writeError(errorMsg);
             return null;
         }
@@ -238,11 +238,11 @@ public class DetectorPlugin extends TestPlugin {
             Files.createDirectories(outputPath);
             Files.write(DetectorPathManager.originalOrderPath(), String.join(System.lineSeparator(), tests).getBytes());
             final Detector detector = DetectorFactory.makeDetector(this.runner, tests, rounds);
-            TestPluginPlugin.info("Created dependent test detector (" + detector.getClass() + ").");
+            TestPluginUtil.info("Created dependent test detector (" + detector.getClass() + ").");
             detector.writeTo(outputPath);
         } else {
             String errorMsg = "Module has no tests, not running detector.";
-            TestPluginPlugin.info(errorMsg);
+            TestPluginUtil.info(errorMsg);
             logger.writeError(errorMsg);
         }
 
@@ -266,7 +266,7 @@ public class DetectorPlugin extends TestPlugin {
             TestFramework testFramework,
             boolean ignoreExisting) throws IOException {
         if (!Files.exists(DetectorPathManager.originalOrderPath()) || ignoreExisting) {
-            TestPluginPlugin.mojo().getLog().info("Getting original order by parsing logs. ignoreExisting set to: " + ignoreExisting);
+            TestPluginUtil.info("Getting original order by parsing logs. ignoreExisting set to: " + ignoreExisting);
 
             try {
                 final Path surefireReportsPath = Paths.get(mavenProject.getBuild().getDirectory()).resolve("surefire-reports");

--- a/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorPlugin.java
@@ -126,7 +126,7 @@ public class DetectorPlugin extends TestPlugin {
             }
         }
 
-        TestPluginUtil.info("TIMEOUT_CALCULATED: Giving " + coordinates + " " + timeout + " seconds to run for " +
+        TestPluginUtil.project.info("TIMEOUT_CALCULATED: Giving " + coordinates + " " + timeout + " seconds to run for " +
             DetectorFactory.detectorType());
 
         return (long) timeout; // Allocate time proportionally
@@ -158,25 +158,25 @@ public class DetectorPlugin extends TestPlugin {
                 final double totalTime = readRealTime(timeCsv);
                 final double mainTimeout = Configuration.config().getProperty("detector.timeout", 6 * 3600.0); // 6 hours
                 if (mainTimeout != 0) {
-                    TestPluginUtil.info("TIMEOUT_VALUE: Using a timeout of "
+                    TestPluginUtil.project.info("TIMEOUT_VALUE: Using a timeout of "
                                                           + mainTimeout + ", and that the total mvn test time is: " + totalTime);
 
                     timeoutRounds = (int) (mainTimeout / totalTime);
                 } else {
                     timeoutRounds = roundNum;
-                    TestPluginUtil.info("TIMEOUT_VALUE specified as 0. " +
+                    TestPluginUtil.project.info("TIMEOUT_VALUE specified as 0. " +
                                                           "Ignoring timeout and using number of rounds.");
                 }
             } else {
                 // Depending on the order in which the developers tell Maven to build modules, some projects like http-request
                 // may not be able to parse the mvn-test-time.log at the base module if other submodules are built first
                 timeoutRounds = roundNum;
-                TestPluginUtil.info("TIMEOUT_VALUE specified but cannot " +
+                TestPluginUtil.project.info("TIMEOUT_VALUE specified but cannot " +
                                                       "read mvn-test-time.log at: " + timeCsv.toString());
-                TestPluginUtil.info("Ignoring timeout and using number of rounds.");
+                TestPluginUtil.project.info("Ignoring timeout and using number of rounds.");
             }
         } else {
-            TestPluginUtil.info("No timeout specified. Using randomize.rounds: " + roundNum);
+            TestPluginUtil.project.info("No timeout specified. Using randomize.rounds: " + roundNum);
             timeoutRounds = roundNum;
         }
 
@@ -187,7 +187,7 @@ public class DetectorPlugin extends TestPlugin {
             rounds = Math.min(timeoutRounds, roundNum);
         }
 
-        TestPluginUtil.info("ROUNDS_CALCULATED: Giving " + coordinates + " "
+        TestPluginUtil.project.info("ROUNDS_CALCULATED: Giving " + coordinates + " "
                 + rounds + " rounds to run for " + DetectorFactory.detectorType());
 
         return rounds;
@@ -224,7 +224,7 @@ public class DetectorPlugin extends TestPlugin {
                     "This project contains both JUnit 4 and JUnit 5 tests, which currently"
                     + " is not supported by iDFlakies";
             }
-            TestPluginUtil.info(errorMsg);
+            TestPluginUtil.project.info(errorMsg);
             logger.writeError(errorMsg);
             return null;
         }
@@ -238,11 +238,11 @@ public class DetectorPlugin extends TestPlugin {
             Files.createDirectories(outputPath);
             Files.write(DetectorPathManager.originalOrderPath(), String.join(System.lineSeparator(), tests).getBytes());
             final Detector detector = DetectorFactory.makeDetector(this.runner, tests, rounds);
-            TestPluginUtil.info("Created dependent test detector (" + detector.getClass() + ").");
+            TestPluginUtil.project.info("Created dependent test detector (" + detector.getClass() + ").");
             detector.writeTo(outputPath);
         } else {
             String errorMsg = "Module has no tests, not running detector.";
-            TestPluginUtil.info(errorMsg);
+            TestPluginUtil.project.info(errorMsg);
             logger.writeError(errorMsg);
         }
 
@@ -266,7 +266,7 @@ public class DetectorPlugin extends TestPlugin {
             TestFramework testFramework,
             boolean ignoreExisting) throws IOException {
         if (!Files.exists(DetectorPathManager.originalOrderPath()) || ignoreExisting) {
-            TestPluginUtil.info("Getting original order by parsing logs. ignoreExisting set to: " + ignoreExisting);
+            TestPluginUtil.project.info("Getting original order by parsing logs. ignoreExisting set to: " + ignoreExisting);
 
             try {
                 final Path surefireReportsPath = Paths.get(project.getBuildDirectory()).resolve("surefire-reports");

--- a/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
@@ -6,7 +6,7 @@ import edu.illinois.cs.testrunner.configuration.Configuration;
 import edu.illinois.cs.testrunner.data.results.Result;
 import edu.illinois.cs.testrunner.data.results.TestResult;
 import edu.illinois.cs.testrunner.data.results.TestRunResult;
-import edu.illinois.cs.testrunner.mavenplugin.TestPluginPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 import edu.illinois.cs.testrunner.runner.Runner;
 
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class DetectorUtil {
             if (allMustPass) {
                 throw new NoPassingOrderException("No passing order for tests (" + originalOrderTries + " runs)");
             } else {
-                TestPluginPlugin.info("No passing order for tests (" + originalOrderTries + " runs). Continuing anyway with last run.");
+                TestPluginUtil.info("No passing order for tests (" + originalOrderTries + " runs). Continuing anyway with last run.");
             }
         }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/DetectorUtil.java
@@ -46,7 +46,7 @@ public class DetectorUtil {
             if (allMustPass) {
                 throw new NoPassingOrderException("No passing order for tests (" + originalOrderTries + " runs)");
             } else {
-                TestPluginUtil.info("No passing order for tests (" + originalOrderTries + " runs). Continuing anyway with last run.");
+                TestPluginUtil.project.info("No passing order for tests (" + originalOrderTries + " runs). Continuing anyway with last run.");
             }
         }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTestList.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTestList.java
@@ -5,7 +5,7 @@ import com.google.gson.Gson;
 import com.reedoei.eunomia.collections.ListUtil;
 import com.reedoei.eunomia.io.files.FileUtil;
 import edu.illinois.cs.testrunner.data.results.Result;
-import edu.illinois.cs.testrunner.mavenplugin.TestPluginPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -22,7 +22,7 @@ public class DependentTestList {
     }
 
     public static DependentTestList fromFile(final Path path) throws IOException {
-        TestPluginPlugin.info("Reading dependent test list from " + path);
+        TestPluginUtil.info("Reading dependent test list from " + path);
         return new Gson().fromJson(FileUtil.readFile(path), DependentTestList.class);
     }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTestList.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTestList.java
@@ -22,7 +22,7 @@ public class DependentTestList {
     }
 
     public static DependentTestList fromFile(final Path path) throws IOException {
-        TestPluginUtil.info("Reading dependent test list from " + path);
+        TestPluginUtil.project.info("Reading dependent test list from " + path);
         return new Gson().fromJson(FileUtil.readFile(path), DependentTestList.class);
     }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/BulkOrderRunnerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/BulkOrderRunnerPlugin.java
@@ -9,7 +9,7 @@ import edu.illinois.cs.testrunner.coreplugin.TestPlugin;
 import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 import edu.illinois.cs.testrunner.runner.Runner;
 import edu.illinois.cs.testrunner.runner.RunnerFactory;
-import org.apache.maven.project.MavenProject;
+import edu.illinois.cs.testrunner.util.ProjectWrapper;
 import scala.Option;
 import scala.util.Try;
 
@@ -23,10 +23,10 @@ import java.util.stream.Collectors;
 
 public class BulkOrderRunnerPlugin extends TestPlugin {
     @Override
-    public void execute(final MavenProject mavenProject) {
-        final ErrorLogger errorLogger = new ErrorLogger(mavenProject);
+    public void execute(final ProjectWrapper project) {
+        final ErrorLogger errorLogger = new ErrorLogger(project);
 
-        final Option<Runner> runnerOption = RunnerFactory.from(mavenProject);
+        final Option<Runner> runnerOption = RunnerFactory.from(project);
 
         errorLogger.runAndLogError(() -> {
             Files.deleteIfExists(DetectorPathManager.errorPath());

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/BulkOrderRunnerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/BulkOrderRunnerPlugin.java
@@ -5,8 +5,8 @@ import edu.illinois.cs.dt.tools.detection.DetectorPathManager;
 import edu.illinois.cs.dt.tools.runner.InstrumentingSmartRunner;
 import edu.illinois.cs.testrunner.configuration.Configuration;
 import edu.illinois.cs.testrunner.data.results.TestRunResult;
-import edu.illinois.cs.testrunner.mavenplugin.TestPlugin;
-import edu.illinois.cs.testrunner.mavenplugin.TestPluginPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 import edu.illinois.cs.testrunner.runner.Runner;
 import edu.illinois.cs.testrunner.runner.RunnerFactory;
 import org.apache.maven.project.MavenProject;
@@ -42,7 +42,7 @@ public class BulkOrderRunnerPlugin extends TestPlugin {
                 run(runner, inputPath, outputPath);
             } else {
                 final String errorMsg = "Module is not using a supported test framework (probably not JUnit).";
-                TestPluginPlugin.info(errorMsg);
+                TestPluginUtil.info(errorMsg);
                 errorLogger.writeError(errorMsg);
             }
 
@@ -54,7 +54,7 @@ public class BulkOrderRunnerPlugin extends TestPlugin {
         final List<Path> collect = Files.list(inputPath).collect(Collectors.toList());
         for (int i = 0; i < collect.size(); i++) {
             final Path p = collect.get(i);
-            TestPluginPlugin.info(String.format("Running (%d of %d): %s", i, collect.size(), p));
+            TestPluginUtil.info(String.format("Running (%d of %d): %s", i, collect.size(), p));
             runOrder(runner, p, outputPath);
         }
     }

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/BulkOrderRunnerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/BulkOrderRunnerPlugin.java
@@ -42,7 +42,7 @@ public class BulkOrderRunnerPlugin extends TestPlugin {
                 run(runner, inputPath, outputPath);
             } else {
                 final String errorMsg = "Module is not using a supported test framework (probably not JUnit).";
-                TestPluginUtil.info(errorMsg);
+                TestPluginUtil.project.info(errorMsg);
                 errorLogger.writeError(errorMsg);
             }
 
@@ -54,7 +54,7 @@ public class BulkOrderRunnerPlugin extends TestPlugin {
         final List<Path> collect = Files.list(inputPath).collect(Collectors.toList());
         for (int i = 0; i < collect.size(); i++) {
             final Path p = collect.get(i);
-            TestPluginUtil.info(String.format("Running (%d of %d): %s", i, collect.size(), p));
+            TestPluginUtil.project.info(String.format("Running (%d of %d): %s", i, collect.size(), p));
             runOrder(runner, p, outputPath);
         }
     }

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/ErrorLogger.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/ErrorLogger.java
@@ -1,7 +1,7 @@
 package edu.illinois.cs.dt.tools.utility;
 
 import edu.illinois.cs.dt.tools.detection.DetectorPathManager;
-import org.apache.maven.project.MavenProject;
+import edu.illinois.cs.testrunner.util.ProjectWrapper;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -15,9 +15,9 @@ import java.util.concurrent.Callable;
 
 public class ErrorLogger {
     private final String coordinates;
-    private final MavenProject project;
+    private final ProjectWrapper project;
 
-    public ErrorLogger(final MavenProject project) {
+    public ErrorLogger(final ProjectWrapper project) {
         this.project = project;
         this.coordinates = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
     }
@@ -26,7 +26,7 @@ public class ErrorLogger {
         return coordinates;
     }
 
-    private String subjectName(final MavenProject project) {
+    private String subjectName(final ProjectWrapper project) {
         final Path relativePath =
                 PathManager.parentPath().getParent().toAbsolutePath()
                         .relativize(project.getBasedir().toPath().toAbsolutePath());

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/ModuleTestTimePlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/ModuleTestTimePlugin.java
@@ -2,7 +2,7 @@ package edu.illinois.cs.dt.tools.utility;
 
 import edu.illinois.cs.dt.tools.detection.DetectorPathManager;
 import edu.illinois.cs.testrunner.coreplugin.TestPlugin;
-import org.apache.maven.project.MavenProject;
+import edu.illinois.cs.testrunner.util.ProjectWrapper;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -24,13 +24,13 @@ public class ModuleTestTimePlugin  extends TestPlugin {
     }
 
     @Override
-    public void execute(final MavenProject mavenProject) {
-        this.coordinates = mavenProject.getGroupId() + ":" + mavenProject.getArtifactId() + ":" + mavenProject.getVersion();
+    public void execute(final ProjectWrapper project) {
+        this.coordinates = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
 
-        final Path surefireReportsPath = Paths.get(mavenProject.getBuild().getDirectory()).resolve("surefire-reports");
+        final Path surefireReportsPath = Paths.get(project.getBuildDirectory()).resolve("surefire-reports");
         final Path mvnTestLog = DetectorPathManager.mvnTestLog();
         try {
-            final Path outputFile = Paths.get(getMavenProjectParent(mavenProject).getBasedir().getAbsolutePath(),
+            final Path outputFile = Paths.get(getMavenProjectParent(project).getBasedir().getAbsolutePath(),
                     "module-test-time.csv");
 
             final String outputStr = coordinates + "," + timeFrom(surefireReportsPath, mvnTestLog);
@@ -53,8 +53,8 @@ public class ModuleTestTimePlugin  extends TestPlugin {
         return 0.0;
     }
 
-    private MavenProject getMavenProjectParent(MavenProject mavenProject) {
-        MavenProject parentProj = mavenProject;
+    private ProjectWrapper getMavenProjectParent(ProjectWrapper project) {
+        ProjectWrapper parentProj = project;
         while (parentProj.getParent() != null && parentProj.getParent().getBasedir() != null) {
             parentProj = parentProj.getParent();
         }

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/ModuleTestTimePlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/ModuleTestTimePlugin.java
@@ -1,7 +1,7 @@
 package edu.illinois.cs.dt.tools.utility;
 
 import edu.illinois.cs.dt.tools.detection.DetectorPathManager;
-import edu.illinois.cs.testrunner.mavenplugin.TestPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPlugin;
 import org.apache.maven.project.MavenProject;
 import org.xml.sax.SAXException;
 

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/PathManager.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/PathManager.java
@@ -2,7 +2,7 @@ package edu.illinois.cs.dt.tools.utility;
 
 import com.google.common.base.Preconditions;
 import edu.illinois.cs.testrunner.configuration.Configuration;
-import edu.illinois.cs.testrunner.mavenplugin.TestPluginPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 import org.apache.maven.project.MavenProject;
 
 import java.io.IOException;
@@ -14,7 +14,7 @@ import java.nio.file.Paths;
 public class PathManager {
     private static final String outputPath = Configuration.config().getProperty("dt.cache.absolute.path", "");
     public static Path modulePath() {
-        return TestPluginPlugin.mavenProject().getBasedir().toPath();
+        return TestPluginUtil.project.getBasedir().toPath();
     }
 
     private static MavenProject getMavenProjectParent(MavenProject mavenProject) {
@@ -26,7 +26,7 @@ public class PathManager {
     }
 
     public static Path parentPath() {
-        return getMavenProjectParent(TestPluginPlugin.mavenProject()).getBasedir().toPath();
+        return getMavenProjectParent(TestPluginUtil.project).getBasedir().toPath();
     }
 
     public static Path parentPath(final Path relative) {
@@ -37,7 +37,7 @@ public class PathManager {
     }
 
     public static Path cachePath() {
-	TestPluginPlugin.mojo().getLog().info("Accessing cachePath: " + outputPath);
+	TestPluginUtil.info("Accessing cachePath: " + outputPath);
 	if (outputPath == "") {
 	    return modulePath().resolve(".dtfixingtools");
 	} else {
@@ -45,7 +45,7 @@ public class PathManager {
 	    try {
 		Files.createDirectories(outputPathObj);
 	    } catch (IOException e) {
-		TestPluginPlugin.mojo().getLog().debug(e.getMessage());
+		TestPluginUtil.debug(e.getMessage());
 	    }
 	    return outputPathObj.resolve(modulePath().getFileName());
 	}

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/PathManager.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/PathManager.java
@@ -3,7 +3,7 @@ package edu.illinois.cs.dt.tools.utility;
 import com.google.common.base.Preconditions;
 import edu.illinois.cs.testrunner.configuration.Configuration;
 import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
-import org.apache.maven.project.MavenProject;
+import edu.illinois.cs.testrunner.util.ProjectWrapper;
 
 import java.io.IOException;
 
@@ -17,8 +17,8 @@ public class PathManager {
         return TestPluginUtil.project.getBasedir().toPath();
     }
 
-    private static MavenProject getMavenProjectParent(MavenProject mavenProject) {
-        MavenProject parentProj = mavenProject;
+    private static ProjectWrapper getMavenProjectParent(ProjectWrapper project) {
+        ProjectWrapper parentProj = project;
         while (parentProj.getParent() != null && parentProj.getParent().getBasedir() != null) {
             parentProj = parentProj.getParent();
         }

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/PathManager.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/PathManager.java
@@ -37,7 +37,7 @@ public class PathManager {
     }
 
     public static Path cachePath() {
-	TestPluginUtil.info("Accessing cachePath: " + outputPath);
+	TestPluginUtil.project.info("Accessing cachePath: " + outputPath);
 	if (outputPath == "") {
 	    return modulePath().resolve(".dtfixingtools");
 	} else {
@@ -45,7 +45,7 @@ public class PathManager {
 	    try {
 		Files.createDirectories(outputPathObj);
 	    } catch (IOException e) {
-		TestPluginUtil.debug(e.getMessage());
+		TestPluginUtil.project.debug(e.getMessage());
 	    }
 	    return outputPathObj.resolve(modulePath().getFileName());
 	}

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/ReplayPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/ReplayPlugin.java
@@ -8,7 +8,7 @@ import edu.illinois.cs.testrunner.coreplugin.TestPlugin;
 import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 import edu.illinois.cs.testrunner.runner.Runner;
 import edu.illinois.cs.testrunner.runner.RunnerFactory;
-import org.apache.maven.project.MavenProject;
+import edu.illinois.cs.testrunner.util.ProjectWrapper;
 import scala.Option;
 import scala.util.Try;
 
@@ -22,8 +22,8 @@ public class ReplayPlugin extends TestPlugin {
     private Path replayPath;
 
     @Override
-    public void execute(final MavenProject mavenProject) {
-        final Option<Runner> runnerOption = RunnerFactory.from(mavenProject);
+    public void execute(final ProjectWrapper project) {
+        final Option<Runner> runnerOption = RunnerFactory.from(project);
 
         if (runnerOption.isDefined()) {
             replayPath = Paths.get(Configuration.config().getProperty("replay.path"));

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/ReplayPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/ReplayPlugin.java
@@ -37,13 +37,13 @@ public class ReplayPlugin extends TestPlugin {
                 if (testRunResultTry.isSuccess()) {
                     Files.write(outputPath, new Gson().toJson(testRunResultTry.get()).getBytes());
                 } else {
-                    TestPluginUtil.error(testRunResultTry.failed().get());
+                    TestPluginUtil.project.error(testRunResultTry.failed().get());
                 }
             } catch (IOException e) {
-                TestPluginUtil.error(e);
+                TestPluginUtil.project.error(e);
             }
         } else {
-            TestPluginUtil.info("Module is not using a supported test framework (probably not JUnit).");
+            TestPluginUtil.project.info("Module is not using a supported test framework (probably not JUnit).");
         }
     }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/ReplayPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/ReplayPlugin.java
@@ -4,8 +4,8 @@ import com.google.gson.Gson;
 import com.reedoei.eunomia.io.files.FileUtil;
 import edu.illinois.cs.testrunner.configuration.Configuration;
 import edu.illinois.cs.testrunner.data.results.TestRunResult;
-import edu.illinois.cs.testrunner.mavenplugin.TestPlugin;
-import edu.illinois.cs.testrunner.mavenplugin.TestPluginPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPlugin;
+import edu.illinois.cs.testrunner.coreplugin.TestPluginUtil;
 import edu.illinois.cs.testrunner.runner.Runner;
 import edu.illinois.cs.testrunner.runner.RunnerFactory;
 import org.apache.maven.project.MavenProject;
@@ -37,13 +37,13 @@ public class ReplayPlugin extends TestPlugin {
                 if (testRunResultTry.isSuccess()) {
                     Files.write(outputPath, new Gson().toJson(testRunResultTry.get()).getBytes());
                 } else {
-                    TestPluginPlugin.mojo().getLog().error(testRunResultTry.failed().get());
+                    TestPluginUtil.error(testRunResultTry.failed().get());
                 }
             } catch (IOException e) {
-                TestPluginPlugin.mojo().getLog().error(e);
+                TestPluginUtil.error(e);
             }
         } else {
-            TestPluginPlugin.mojo().getLog().info("Module is not using a supported test framework (probably not JUnit).");
+            TestPluginUtil.info("Module is not using a supported test framework (probably not JUnit).");
         }
     }
 


### PR DESCRIPTION
Hi, I'm Binyao Jiang attending CS527 this semester and my project is to extend idflakies and testrunner to be gradle compatible.

This PR depends on this testrunner open PR: https://github.com/TestingResearchIllinois/testrunner/pull/16 and another iDFlakies open pr: https://github.com/idflakies/iDFlakies/pull/28.

Following is the explanation for the PR commits:
1st commit: Rebase the codebase to the open PR: https://github.com/idflakies/iDFlakies/pull/28 since we have to modify multiple same files simultaneously.
2nd commit: Update when Testrunner moves core plugin to coreplugin module.
3rd commit: Update when Testrunner wraps MavenProject object into ProjectWrapper. After this step, iDFlakies's interface will be maven/gradle irrelevant so that we can use the same iDFlakies code to generate iDFlakies maven plugin and gradle plugin.
