### PR TITLE
Bug fix for running in Windows OS.

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/runner/InstrumentingSmartRunner.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/runner/InstrumentingSmartRunner.java
@@ -48,9 +48,11 @@ public class InstrumentingSmartRunner extends SmartRunner {
 
     @Override
     public Try<TestRunResult> runWithCp(final String cp, final Stream<String> testOrder) {
-        // Save stdout,stderr, and run result to a file
-        final Try<Try<TestRunResult>> result = TempFiles.withTempFile(outputPath -> {
             try {
+                Path outputPath = null;
+                    File tmp = File.createTempFile("temp", ".tmp");
+                    String pathstr = tmp.getAbsolutePath();
+                    outputPath = Paths.get(pathstr);
                 writeTo(outputPath);
 
                 final Try<TestRunResult> testRunResultTry = super.runWithCp(cp, testOrder);
@@ -58,14 +60,11 @@ public class InstrumentingSmartRunner extends SmartRunner {
                 if (testRunResultTry.isSuccess()) {
                     RunnerPathManager.outputResult(outputPath, testRunResultTry.get());
                 }
-
+                tmp.deleteOnExit();
                 return testRunResultTry;
             } catch (Exception e){
                 return new Failure<>(e);
             }
-        });
-
-        return result.get();
     }
 
     private void writeTo(final Path outputPath) {


### PR DESCRIPTION
To solve error 'The process cannot access the file because it is being used by another process' in Windows OS.
**_But it is not enough and should this change continued to  SmartRunner base class_**.