### PR TITLE
Keep track of NOD tests and distinguish between OD and NOD tests

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/detection/detectors/ReverseDetector.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/detectors/ReverseDetector.java
@@ -3,8 +3,9 @@ package edu.illinois.cs.dt.tools.detection.detectors;
 import edu.illinois.cs.dt.tools.detection.DetectionRound;
 import edu.illinois.cs.dt.tools.detection.DetectorUtil;
 import edu.illinois.cs.dt.tools.detection.TestShuffler;
+import edu.illinois.cs.dt.tools.detection.filters.ConfirmationFilter;
 import edu.illinois.cs.dt.tools.detection.filters.UniqueFilter;
-import edu.illinois.cs.dt.tools.detection.filters.VerifyFilter;
+import edu.illinois.cs.dt.tools.runner.InstrumentingSmartRunner;
 import edu.illinois.cs.testrunner.data.results.TestRunResult;
 import edu.illinois.cs.testrunner.runner.Runner;
 
@@ -23,8 +24,13 @@ public class ReverseDetector extends ExecutingDetector {
 
         testShuffler = new TestShuffler(name, rounds, tests);
 
+        // Filters to be applied in order
+        if (runner instanceof InstrumentingSmartRunner) {
+            addFilter(new ConfirmationFilter(name, tests, (InstrumentingSmartRunner) runner));
+        } else {
+            addFilter(new ConfirmationFilter(name, tests, InstrumentingSmartRunner.fromRunner(runner)));
+        }
         addFilter(new UniqueFilter());
-        addFilter(new VerifyFilter(name, runner));
     }
 
     @Override

--- a/src/main/java/edu/illinois/cs/dt/tools/detection/filters/ConfirmationFilter.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/detection/filters/ConfirmationFilter.java
@@ -6,6 +6,7 @@ import edu.illinois.cs.dt.tools.detection.DetectionRound;
 import edu.illinois.cs.dt.tools.detection.DetectorPathManager;
 import edu.illinois.cs.dt.tools.runner.InstrumentingSmartRunner;
 import edu.illinois.cs.dt.tools.runner.data.DependentTest;
+import edu.illinois.cs.dt.tools.runner.data.DependentTestType;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -58,8 +59,9 @@ public class ConfirmationFilter implements Filter {
                 return confirmation(true, "confirmation-sampling", dependentTest, absoluteRound);
             }
 
-            // This test is known to be flaky, so it should never make it past the filter
-            return false;
+            // This test is known to be flaky, so set its type to NOD but still keep the test
+            dependentTest.setType(DependentTestType.NOD);
+            return true;
         } else if (knownDep.contains(dependentTest.name())) {
             if (new Random().nextDouble() < DEPENDENT_CONFIRMATION_SAMPLING_RATE) {
                 return confirmation(false, "confirmation-sampling", dependentTest, absoluteRound);
@@ -83,12 +85,14 @@ public class ConfirmationFilter implements Filter {
             } else {
                 knownFlaky.add(dependentTest.name());
                 knownDep.remove(dependentTest.name());
+                dependentTest.setType(DependentTestType.NOD);   // Set the type to be NOD
             }
         }
 
         // Should never keep flaky tests (keeping mean it's dependent in this case)
         if (isFlaky) {
-            return false;
+            dependentTest.setType(DependentTestType.NOD);   // Just in case, ensure it is marked NOD
+            return true;
         }
 
         return confirmed;

--- a/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTest.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTest.java
@@ -14,10 +14,13 @@ public class DependentTest {
     private final TestRun intended;
     private final TestRun revealed;
 
+    private DependentTestType type;
+
     public DependentTest(final String name, final TestRun intended, final TestRun revealed) {
         this.name = name;
         this.intended = intended;
         this.revealed = revealed;
+        this.type = DependentTestType.OD;   // Start as OD unless proven otherwise
     }
 
     public String name() {
@@ -30,6 +33,14 @@ public class DependentTest {
 
     public TestRun revealed() {
         return revealed;
+    }
+
+    public DependentTestType type() {
+        return type;
+    }
+
+    public void setType(DependentTestType type) {
+        this.type = type;
     }
 
     @Override

--- a/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTestType.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/runner/data/DependentTestType.java
@@ -1,0 +1,6 @@
+package edu.illinois.cs.dt.tools.runner.data;
+
+public enum DependentTestType {
+    OD,
+    NOD
+}


### PR DESCRIPTION
Currently our data structure for a detected dependent test does not keep track of whether it is OD or NOD. Further, our default detector RandomDetector uses the ConfirmationFilter that only keeps a detected flaky test if it confirms to always pass in a previous passing order and always fails in a separate failing order. As such, it simply discards any NOD tests. As to make it easier to keep track of all detected flaky tests, both OD and NOD, and also to distinguish between the two, this pull request introduces a new DependentTestType enum to keep track of that type and extends the DependentTest data structure to record this type, which would then propagate to the outputted flaky-lists.json file.

This change further ensures that ReverseDetector, which previously was just using the VerifyFilter and not the ConfirmationFilter, also uses the same logic to distinguish between any OD or NOD tests it detects.