### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/test-many-configs-legacy.yml
+++ b/.github/workflows/test-many-configs-legacy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages

--- a/.github/workflows/test-many-configs-maven-plugin.yml
+++ b/.github/workflows/test-many-configs-maven-plugin.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages

--- a/.github/workflows/test-many-projects-legacy.yml
+++ b/.github/workflows/test-many-projects-legacy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages
@@ -40,7 +40,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages
@@ -68,7 +68,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages
@@ -96,7 +96,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages

--- a/.github/workflows/test-many-projects-maven-plugin.yml
+++ b/.github/workflows/test-many-projects-maven-plugin.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages
@@ -40,7 +40,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages
@@ -68,7 +68,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages
@@ -96,7 +96,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8.0.292+1'
+          java-version: '8.0.292+10'
           distribution: 'adopt'
 
       - name: Installs packages

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,12 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.5</version>
+                <version>2.8.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>25.1-jre</version>
+                <version>29.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.reedoei</groupId>
@@ -112,7 +112,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>
@@ -122,12 +122,12 @@
             <dependency>
                 <groupId>org.dom4j</groupId>
                 <artifactId>dom4j</artifactId>
-                <version>2.1.1</version>
+                <version>2.1.3</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
-                <version>3.25.2</version>
+                <version>3.41.2.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>29.0-jre</version>
+                <version>32.0.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.reedoei</groupId>

--- a/scripts/idfProjects2.csv
+++ b/scripts/idfProjects2.csv
@@ -1,7 +1,6 @@
 #Project,SHA,module,expectedFlakyTests
 https://github.com/ktuukkan/marine-api,af0003847db9ba822f67d4f1dceb8de3fe63250a,,12
 https://github.com/sonatype-nexus-community/nexus-repository-helm,60a9e8de0d97bfa4e3f7ee6bb87d518e398f03f2,,0
-https://github.com/spring-projects/spring-data-envers,5637994be37747e82b2d6d5b34555e2bee791fe6,,0
 https://github.com/spring-projects/spring-ws,e8d89c9eb0929dda304174729c9c69fb29f448eb,spring-ws-security,0
 https://github.com/tbsalling/aismessages,7b0c4c708b6bb9a6da3d5737bcad1857ade8a931,,2
 https://github.com/tools4j/unix4j,367da7d262e682a08577cdf19ebbbdd8a46870fe,unix4j-core/unix4j-command,1


### PR DESCRIPTION
This pull request updates the third-party library dependencies for iDFlakies, updates the GitHub Actions workflow to use a different Java 8 version as the one we currently use is no longer available, and also removes a project `spring-data-envers` from the testing scripts since that project is no longer buildable due to it having SNAPSHOT dependencies that are no longer accessible.